### PR TITLE
Updated VisualStudioInfo.html with new Visual Studio 2022 version 17.…

### DIFF
--- a/pages/TechnicalPaper/TechnicalPaper.html
+++ b/pages/TechnicalPaper/TechnicalPaper.html
@@ -75,7 +75,7 @@
           <li>Installer option: Mobile development with .NET</li>
        </ul>
        <p>For gamers who want to play:</p>
-       <a target="_blank" href="https://dotnet.microsoft.com/en-us/download/dotnet/thank-you/runtime-6.0.12-windows-x64-installer">Microsoft .NET 6 Runtime</a>
+       <a target="_blank" href="https://dotnet.microsoft.com/en-us/download/dotnet/thank-you/runtime-6.0.13-windows-x64-installer">Microsoft .NET 6 Runtime</a>
        <p>
           Note:&nbsp; If you want to use Eamon CS with a .NET Standard 2.0 compliant runtime already on your system (that isn't .NET 6.X), see the <a href="#ECSTP3">POST-INSTALLATION TOPICS</a> section for details on how to do that.
        </p>

--- a/pages/VisualStudioInfo.html
+++ b/pages/VisualStudioInfo.html
@@ -8,8 +8,8 @@
        <h4>VISUAL STUDIO INFORMATION</h4>
        <pre>
 Microsoft Visual Studio Community 2022
-Version 17.4.3
-VisualStudio.17.Release/17.4.3+33205.214
+Version 17.4.4
+VisualStudio.17.Release/17.4.4+33213.308
 Microsoft .NET Framework
 Version 4.8.04084
 
@@ -21,7 +21,7 @@ ASP.NET and Web Tools
 Azure App Service Tools v3.0.0   17.4.326.54890
 Azure App Service Tools v3.0.0
 
-C# Tools   4.4.0-6.22580.4+d7a61210a88b584ca0827585ec6e871c6b1c5a14
+C# Tools   4.4.0-6.22608.27+af1e46ad38d900023f8b1a2839484e471ece1502
 C# components used in the IDE. Depending on your project type and settings, a different version of the compiler may be used.
 
 Extensibility Message Bus   1.4.1 (main@2ee106a)
@@ -42,7 +42,7 @@ Provides languages services for ASP.NET Core Razor.
 TypeScript Tools   17.0.10921.2001
 TypeScript Tools for Microsoft Visual Studio
 
-Visual Basic Tools   4.4.0-6.22580.4+d7a61210a88b584ca0827585ec6e871c6b1c5a14
+Visual Basic Tools   4.4.0-6.22608.27+af1e46ad38d900023f8b1a2839484e471ece1502
 Visual Basic components used in the IDE. Depending on your project type and settings, a different version of the compiler may be used.
 
 Visual F# Tools   17.4.0-beta.22512.4+525d5109e389341bb90b144c24e2ad1ceec91e7b


### PR DESCRIPTION
…4.4 and .NET 6.0 Runtime upgrade to v6.0.13.